### PR TITLE
Prune unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1291,7 +1291,9 @@ dependencies = [
  "log",
  "regex",
  "reqwest",
+ "serde",
  "tokio",
+ "toml",
  "zip",
 ]
 
@@ -1408,18 +1410,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1436,6 +1448,15 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1690,6 +1711,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "tower"
@@ -2160,6 +2220,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "roblox-packages"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,12 +562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,7 +1288,6 @@ dependencies = [
  "console",
  "copy_dir",
  "env_logger",
- "glob",
  "log",
  "regex",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1294,7 @@ dependencies = [
  "console",
  "copy_dir",
  "env_logger",
+ "glob",
  "log",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,7 @@ env_logger = { version = "0.11.8", default-features = false }
 log = "0.4.28"
 regex = "1.11.2"
 reqwest = { version = "0.12.23", features = ["json"] }
+serde = { version = "1.0.228", features = ["derive"] }
 tokio = { version = "1.47.1", features = ["full"] }
+toml = "0.9.8"
 zip = "5.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ clap = { version = "4.5.47", features = ["derive"] }
 console = "0.16.0"
 copy_dir = "0.1.3"
 env_logger = { version = "0.11.8", default-features = false }
-glob = "0.3.3"
 log = "0.4.28"
 regex = "1.11.2"
 reqwest = { version = "0.12.23", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4.5.47", features = ["derive"] }
 console = "0.16.0"
 copy_dir = "0.1.3"
 env_logger = { version = "0.11.8", default-features = false }
+glob = "0.3.3"
 log = "0.4.28"
 regex = "1.11.2"
 reqwest = { version = "0.12.23", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roblox-packages"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [lib]

--- a/src/command.rs
+++ b/src/command.rs
@@ -15,6 +15,11 @@ pub enum Command {
         /// The Roblox version hash to download packages from
         #[arg(short, long)]
         version: Option<String>,
+
+        /// Optional list of package names to install (e.g. "Foundation",
+        /// "Signals", "SignalsReact")
+        #[arg(short, long)]
+        dependencies: Option<Vec<String>>,
     },
 
     /// Lists the most recent versions of Roblox
@@ -36,8 +41,12 @@ pub struct CLI {
 impl CLI {
     pub async fn run(&self) -> Result<(), reqwest::Error> {
         match &self.command {
-            Command::Install { dest, version } => {
-                install_roblox_packages(dest, version).await?;
+            Command::Install {
+                dest,
+                version,
+                dependencies,
+            } => {
+                install_roblox_packages(dest, version, dependencies).await?;
             }
             Command::List { limit } => list_roblox_versions(limit).await?,
         }

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,8 +1,8 @@
 use log::{debug, info};
 use serde::Deserialize;
 use std::env::current_dir;
-use std::fs;
 use std::path::{Path, PathBuf};
+use std::{fs, vec};
 
 use crate::roblox::{
     fetch_roblox_deploy_history, fetch_roblox_packages, get_roblox_version_by_git_hash,
@@ -15,6 +15,63 @@ const INDEX_PATH: &str = "Packages/_Index";
 #[derive(Deserialize, Debug)]
 struct RotrieverPackageLockfile {
     dependencies: Option<Vec<String>>,
+}
+
+fn prune_unused_dependencies(dependencies: &Vec<String>, packages_path: &Path) {
+    info!("pruning unused dependencies");
+
+    info!("root dependencies to keep: {:?}", dependencies);
+
+    fn process_dependency(
+        dependency: &str,
+        packages_path: &Path,
+        dependencies_to_keep: &mut Vec<String>,
+    ) {
+        info!("keeping dependency: {}", dependency);
+
+        // TODO: Handle if there are multiple versions of a package. i.e. if we
+        // want to include Foundation as a dependency, we need to make sure we
+        // use the right one. Maybe the most up-to-date?
+
+        let dependency_path = packages_path.join(INDEX_PATH).join(dependency);
+
+        let lockfile_path = dependency_path.join(LOCKFILE_NAME);
+        let lockfile_content = fs::read_to_string(lockfile_path).expect("Failed to read lockfile");
+
+        let lockfile: RotrieverPackageLockfile =
+            toml::from_str(&lockfile_content).expect("Failed to parse TOML");
+
+        // TODO: Traverse over the dependencies to keep, use their lockfiles
+        // to determine which _other_ dependencies to keep, and then remove
+        // everything in the index and root of RobloxPackages that isn't in
+        // the keep list.
+
+        if let Some(deps) = lockfile.dependencies {
+            for sub_dependency in &deps {
+                let sub_dependency_parts: Vec<&str> = sub_dependency.split(" ").collect();
+                let sub_dependency_name = sub_dependency_parts[1];
+
+                info!("keeping dependency: {}", sub_dependency_name);
+
+                dependencies_to_keep.push(sub_dependency_name.to_string());
+
+                process_dependency(sub_dependency_name, packages_path, dependencies_to_keep);
+
+                // TODO: Go up into the index and process the sub-dependency
+
+                // TODO: Traverse over the dependencies of these
+                // dependencies and so on until we have the full picture
+            }
+        }
+    }
+
+    let mut dependencies_to_keep: Vec<String> = vec![];
+
+    for dependency in dependencies {
+        process_dependency(dependency, packages_path, &mut dependencies_to_keep);
+    }
+
+    info!("dependencies to keep: {:?}", dependencies_to_keep);
 }
 
 pub async fn install_roblox_packages(
@@ -69,31 +126,7 @@ pub async fn install_roblox_packages(
     }
 
     if let Some(dependencies) = dependencies {
-        debug!("dependencies to keep: {:?}", dependencies);
-        info!("pruning unused dependencies");
-
-        for dependency in dependencies {
-            // TODO: Handle if there are multiple versions of a package. i.e. if we
-            // want to include Foundation as a dependency, we need to make sure we
-            // use the right one. Maybe the most up-to-date?
-            let dependency_path = dest_path.join(INDEX_PATH).join(dependency);
-
-            let lockfile_path = dependency_path.join(LOCKFILE_NAME);
-            let lockfile_content =
-                fs::read_to_string(lockfile_path).expect("Failed to read lockfile");
-
-            let lockfile: RotrieverPackageLockfile =
-                toml::from_str(&lockfile_content).expect("Failed to parse TOML");
-
-            if let Some(deps) = lockfile.dependencies {
-                info!("keeping dependencies: {:?}", deps);
-            }
-
-            // TODO: Traverse over the dependencies to keep, use their lockfiles
-            // to determine which _other_ dependencies to keep, and then remove
-            // everything in the index and root of RobloxPackages that isn't in
-            // the keep list.
-        }
+        prune_unused_dependencies(dependencies, &dest_path);
     }
 
     info!(

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,4 +1,5 @@
 use log::{debug, info};
+use serde::Deserialize;
 use std::env::current_dir;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -7,9 +8,19 @@ use crate::roblox::{
     fetch_roblox_deploy_history, fetch_roblox_packages, get_roblox_version_by_git_hash,
 };
 
+// Name of the lockfile included in each Rotriever package
+const LOCKFILE_NAME: &str = "lock.toml";
+const INDEX_PATH: &str = "Packages/_Index";
+
+#[derive(Deserialize, Debug)]
+struct RotrieverPackageLockfile {
+    dependencies: Option<Vec<String>>,
+}
+
 pub async fn install_roblox_packages(
     dest: &PathBuf,
     version: &Option<String>,
+    dependencies: &Option<Vec<String>>,
 ) -> Result<(), reqwest::Error> {
     let version_history = fetch_roblox_deploy_history().await?;
 
@@ -54,6 +65,34 @@ pub async fn install_roblox_packages(
             }
             let mut outfile = fs::File::create(&outpath).unwrap();
             std::io::copy(&mut file, &mut outfile).unwrap();
+        }
+    }
+
+    if let Some(dependencies) = dependencies {
+        debug!("dependencies to keep: {:?}", dependencies);
+        info!("pruning unused dependencies");
+
+        for dependency in dependencies {
+            // TODO: Handle if there are multiple versions of a package. i.e. if we
+            // want to include Foundation as a dependency, we need to make sure we
+            // use the right one. Maybe the most up-to-date?
+            let dependency_path = dest_path.join(INDEX_PATH).join(dependency);
+
+            let lockfile_path = dependency_path.join(LOCKFILE_NAME);
+            let lockfile_content =
+                fs::read_to_string(lockfile_path).expect("Failed to read lockfile");
+
+            let lockfile: RotrieverPackageLockfile =
+                toml::from_str(&lockfile_content).expect("Failed to parse TOML");
+
+            if let Some(deps) = lockfile.dependencies {
+                info!("keeping dependencies: {:?}", deps);
+            }
+
+            // TODO: Traverse over the dependencies to keep, use their lockfiles
+            // to determine which _other_ dependencies to keep, and then remove
+            // everything in the index and root of RobloxPackages that isn't in
+            // the keep list.
         }
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,78 +1,13 @@
 use log::{debug, info};
-use serde::Deserialize;
 use std::env::current_dir;
+use std::fs;
 use std::path::{Path, PathBuf};
-use std::{fs, vec};
 
 use crate::roblox::{
     fetch_roblox_deploy_history, fetch_roblox_packages, get_roblox_version_by_git_hash,
 };
 
-// Name of the lockfile included in each Rotriever package
-const LOCKFILE_NAME: &str = "lock.toml";
-const INDEX_PATH: &str = "Packages/_Index";
-
-#[derive(Deserialize, Debug)]
-struct RotrieverPackageLockfile {
-    dependencies: Option<Vec<String>>,
-}
-
-fn prune_unused_dependencies(dependencies: &Vec<String>, packages_path: &Path) {
-    info!("pruning unused dependencies");
-
-    info!("root dependencies to keep: {:?}", dependencies);
-
-    fn process_dependency(
-        dependency: &str,
-        packages_path: &Path,
-        dependencies_to_keep: &mut Vec<String>,
-    ) {
-        info!("keeping dependency: {}", dependency);
-
-        // TODO: Handle if there are multiple versions of a package. i.e. if we
-        // want to include Foundation as a dependency, we need to make sure we
-        // use the right one. Maybe the most up-to-date?
-
-        let dependency_path = packages_path.join(INDEX_PATH).join(dependency);
-
-        let lockfile_path = dependency_path.join(LOCKFILE_NAME);
-        let lockfile_content = fs::read_to_string(lockfile_path).expect("Failed to read lockfile");
-
-        let lockfile: RotrieverPackageLockfile =
-            toml::from_str(&lockfile_content).expect("Failed to parse TOML");
-
-        // TODO: Traverse over the dependencies to keep, use their lockfiles
-        // to determine which _other_ dependencies to keep, and then remove
-        // everything in the index and root of RobloxPackages that isn't in
-        // the keep list.
-
-        if let Some(deps) = lockfile.dependencies {
-            for sub_dependency in &deps {
-                let sub_dependency_parts: Vec<&str> = sub_dependency.split(" ").collect();
-                let sub_dependency_name = sub_dependency_parts[1];
-
-                info!("keeping dependency: {}", sub_dependency_name);
-
-                dependencies_to_keep.push(sub_dependency_name.to_string());
-
-                process_dependency(sub_dependency_name, packages_path, dependencies_to_keep);
-
-                // TODO: Go up into the index and process the sub-dependency
-
-                // TODO: Traverse over the dependencies of these
-                // dependencies and so on until we have the full picture
-            }
-        }
-    }
-
-    let mut dependencies_to_keep: Vec<String> = vec![];
-
-    for dependency in dependencies {
-        process_dependency(dependency, packages_path, &mut dependencies_to_keep);
-    }
-
-    info!("dependencies to keep: {:?}", dependencies_to_keep);
-}
+use crate::rotriever::prune_unused_dependencies;
 
 pub async fn install_roblox_packages(
     dest: &PathBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ mod command;
 mod install;
 mod list;
 mod roblox;
+mod rotriever;
 
 pub use command::CLI;

--- a/src/rotriever.rs
+++ b/src/rotriever.rs
@@ -1,0 +1,166 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use glob::glob;
+use log::info;
+use serde::Deserialize;
+
+// Collection of functions for working with Rotriever's package index
+
+// Name of the lockfile included in each Rotriever package
+const LOCKFILE_NAME: &str = "rotriever.lock";
+
+#[derive(Deserialize, Debug, Clone)]
+struct RotrieverLockfilePackage {
+    name: String,
+    version: String,
+    dependencies: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct RotrieverLockfile {
+    package: Vec<RotrieverLockfilePackage>,
+}
+
+fn get_package_path_from_index(
+    package_name: &str,
+    package_version: &str,
+    rotriever_index_path: &Path,
+) -> Option<PathBuf> {
+    let package_path = rotriever_index_path.join(package_name);
+
+    // Sometimes we'll get lucky and the package will match its name exactly
+    if package_path.exists() {
+        return Some(package_path);
+    }
+
+    let full_package_path =
+        rotriever_index_path.join(format!("{}-*-{}", package_name, package_version));
+
+    let package_path_pattern = full_package_path
+        .to_str()
+        .expect("Failed to convert path to string");
+
+    for entry in glob(&package_path_pattern).expect("Failed to read glob pattern") {
+        match entry {
+            Ok(path) => {
+                if path.is_dir() {
+                    return Some(path);
+                }
+            }
+            Err(e) => println!("{:?}", e),
+        }
+    }
+
+    None
+}
+
+fn get_packages_to_keep(package_names: &Vec<String>, dest_path: &Path) -> Vec<PathBuf> {
+    let lockfile_content =
+        fs::read_to_string(dest_path.join(LOCKFILE_NAME)).expect("Failed to read rotriever.lock");
+    let lockfile: RotrieverLockfile =
+        toml::from_str(&lockfile_content).expect("Failed to parse rotriever.lock as TOML");
+
+    let rotriever_index_path = dest_path.join("Packages/_Index");
+
+    let mut packages_to_keep: Vec<PathBuf> = vec![];
+
+    // The goal is to know which folders to keep and which ones to prune
+
+    // TODO: Bundle up this loop into a new function that returns a list of paths to keep
+    for package in lockfile.package {
+        if package_names.contains(&package.name) {
+            let package_dependencies = package.dependencies.clone().unwrap_or(vec![]);
+
+            let root_dependency_path =
+                get_package_path_from_index(&package.name, &package.version, &rotriever_index_path);
+
+            if root_dependency_path.is_some() {
+                info!(
+                    "found source for {} at {}",
+                    package.name,
+                    root_dependency_path.unwrap().display()
+                );
+            }
+
+            for dependency in package_dependencies {
+                let parts = dependency.split(" ").collect::<Vec<&str>>();
+                let package_name = parts[1];
+                let package_version = parts[2];
+
+                info!(
+                    "processing dependency: {} {}",
+                    package_name, package_version
+                );
+
+                let dependency_path = get_package_path_from_index(
+                    &package_name,
+                    &package_version,
+                    &rotriever_index_path,
+                );
+
+                // info!(
+                //     "dependency path for {}: {:?}",
+                //     package_name, dependency_path
+                // );
+            }
+        }
+    }
+
+    // fn process_dependency(
+    //     package_name: &str,
+    //     packages_path: &Path,
+    //     packages_to_keep: &mut Vec<String>,
+    // ) {
+    //     info!("keeping dependency: {}", package_name);
+
+    //     // TODO: Handle if there are multiple versions of a package. i.e. if we
+    //     // want to include Foundation as a dependency, we need to make sure we
+    //     // use the right one. Maybe the most up-to-date?
+
+    //     let dependency_path = packages_path.join(INDEX_PATH).join(package_name);
+
+    //     let lockfile_path = dependency_path.join(LOCKFILE_NAME);
+    //     let lockfile_content = fs::read_to_string(lockfile_path).expect("Failed to read lockfile");
+
+    //     let lockfile: RotrieverLockfile =
+    //         toml::from_str(&lockfile_content).expect("Failed to parse TOML");
+
+    //     // TODO: Traverse over the dependencies to keep, use their lockfiles
+    //     // to determine which _other_ dependencies to keep, and then remove
+    //     // everything in the index and root of RobloxPackages that isn't in
+    //     // the keep list.
+
+    //     if let Some(deps) = lockfile.dependencies {
+    //         for sub_dependency in &deps {
+    //             let sub_dependency_parts: Vec<&str> = sub_dependency.split(" ").collect();
+    //             let sub_package_name = sub_dependency_parts[1];
+
+    //             info!("keeping dependency: {}", sub_package_name);
+
+    //             packages_to_keep.push(sub_package_name.to_string());
+
+    //             process_dependency(sub_package_name, packages_path, packages_to_keep);
+
+    //             // TODO: Go up into the index and process the sub-dependency
+
+    //             // TODO: Traverse over the dependencies of these
+    //             // dependencies and so on until we have the full picture
+    //         }
+    //     }
+    // }
+
+    packages_to_keep
+}
+
+pub fn prune_unused_dependencies(package_names: &Vec<String>, dest_path: &Path) {
+    info!("root packages to keep: {:?}", package_names);
+    let packages_to_keep = get_packages_to_keep(package_names, dest_path);
+
+    // TODO: Loop over both `Packages` and `Packages/_Index` and remove all
+    // folders/files whose names don't match
+
+    info!("dependencies to keep: {:?}", packages_to_keep);
+}

--- a/src/rotriever.rs
+++ b/src/rotriever.rs
@@ -1,16 +1,14 @@
+use glob::glob;
+use log::debug;
+use serde::Deserialize;
 use std::{
     fs,
     path::{Path, PathBuf},
 };
 
-use glob::glob;
-use log::{debug, info};
-use serde::Deserialize;
-
 // Collection of functions for working with Rotriever's package index
 
-// Name of the lockfile included in each Rotriever package
-const LOCKFILE_NAME: &str = "rotriever.lock";
+const ROTRIEVER_LOCKFILE_NAME: &str = "rotriever.lock";
 
 #[derive(Deserialize, Debug, Clone)]
 struct RotrieverLockfilePackage {
@@ -94,18 +92,14 @@ fn get_package_from_dependency_string(
 }
 
 fn get_packages_to_keep(package_names: &Vec<String>, dest_path: &Path) -> Vec<PathBuf> {
-    let lockfile_content =
-        fs::read_to_string(dest_path.join(LOCKFILE_NAME)).expect("Failed to read rotriever.lock");
+    let lockfile_content = fs::read_to_string(dest_path.join(ROTRIEVER_LOCKFILE_NAME))
+        .expect("Failed to read rotriever.lock");
     let rotriever_lockfile: RotrieverLockfile =
         toml::from_str(&lockfile_content).expect("Failed to parse rotriever.lock as TOML");
 
     let rotriever_index_path = dest_path.join("Packages/_Index");
 
     let mut packages_to_keep: Vec<PathBuf> = vec![];
-
-    // The goal is to know which folders to keep and which ones to prune
-
-    // TODO: Don't add duplicates
 
     fn process(
         package: &RotrieverLockfilePackage,
@@ -119,11 +113,11 @@ fn get_packages_to_keep(package_names: &Vec<String>, dest_path: &Path) -> Vec<Pa
             get_package_path_from_index(&package.name, &package.version, &rotriever_index_path)
         {
             if packages_to_keep.contains(&root_dependency_path) {
-                info!("already processed {}, skipping", package.name);
+                debug!("already processed {}, skipping", package.name);
                 return;
             }
 
-            info!(
+            debug!(
                 "found source for {} at {}",
                 package.name,
                 root_dependency_path.display()
@@ -147,7 +141,7 @@ fn get_packages_to_keep(package_names: &Vec<String>, dest_path: &Path) -> Vec<Pa
 
     for package_name in package_names {
         if let Some(package) = get_package(package_name, None, &rotriever_lockfile) {
-            info!("processing top-level package: {}", package.name);
+            debug!("processing top-level package: {}", package.name);
             process(
                 &package,
                 &rotriever_lockfile,
@@ -161,7 +155,6 @@ fn get_packages_to_keep(package_names: &Vec<String>, dest_path: &Path) -> Vec<Pa
 }
 
 pub fn prune_unused_dependencies(package_names: &Vec<String>, dest_path: &Path) {
-    info!("root packages to keep: {:?}", package_names);
     let packages_to_keep = get_packages_to_keep(package_names, dest_path);
 
     debug!("packages to keep: {:?}", packages_to_keep);
@@ -189,14 +182,14 @@ pub fn prune_unused_dependencies(package_names: &Vec<String>, dest_path: &Path) 
 
         for package_name_to_keep in package_names {
             if entry.file_name().to_string_lossy() == format!("{}.lua", package_name_to_keep) {
-                info!("keeping {}", entry.path().display());
+                debug!("keeping {}", entry.path().display());
                 should_remove = false;
                 continue;
             }
         }
 
         if should_remove {
-            info!("removing unused package: {}", entry.path().display());
+            debug!("removing unused linker module: {}", entry.path().display());
             if entry.path().is_dir() {
                 fs::remove_dir_all(entry.path()).expect("Failed to remove directory");
             } else {
@@ -222,14 +215,14 @@ pub fn prune_unused_dependencies(package_names: &Vec<String>, dest_path: &Path) 
 
         for package_path_to_keep in &packages_to_keep {
             if entry.path() == *package_path_to_keep {
-                info!("keeping {}", entry.path().display());
+                debug!("keeping {}", entry.path().display());
                 should_remove = false;
                 continue;
             }
         }
 
         if should_remove {
-            info!("removing unused package index: {}", entry.path().display());
+            debug!("removing unused package: {}", entry.path().display());
             if entry.path().is_dir() {
                 fs::remove_dir_all(entry.path()).expect("Failed to remove directory");
             } else {

--- a/src/rotriever.rs
+++ b/src/rotriever.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use glob::glob;
-use log::info;
+use log::{debug, info};
 use serde::Deserialize;
 
 // Collection of functions for working with Rotriever's package index
@@ -57,10 +57,46 @@ fn get_package_path_from_index(
     None
 }
 
+fn get_package(
+    package_name: &str,
+    package_version: Option<&str>,
+    rotriever_lockfile: &RotrieverLockfile,
+) -> Option<RotrieverLockfilePackage> {
+    for package in &rotriever_lockfile.package {
+        if package.name == package_name {
+            if let Some(version) = package_version {
+                if package.version != version {
+                    continue;
+                }
+            }
+            return Some(package.clone());
+        }
+    }
+    None
+}
+
+// Rotriever stores package dependencies as "<consumer_name> <package_name>
+// <version> <source>". This function parses that and finds the actual
+// package in the lockfile
+fn get_package_from_dependency_string(
+    dependency_string: String,
+    rotriever_lockfile: &RotrieverLockfile,
+) -> Option<RotrieverLockfilePackage> {
+    let parts = dependency_string.split(" ").collect::<Vec<&str>>();
+    if parts.len() < 4 {
+        return None;
+    }
+
+    let package_name = parts[1];
+    let package_version = parts[2];
+
+    get_package(package_name, Some(package_version), rotriever_lockfile)
+}
+
 fn get_packages_to_keep(package_names: &Vec<String>, dest_path: &Path) -> Vec<PathBuf> {
     let lockfile_content =
         fs::read_to_string(dest_path.join(LOCKFILE_NAME)).expect("Failed to read rotriever.lock");
-    let lockfile: RotrieverLockfile =
+    let rotriever_lockfile: RotrieverLockfile =
         toml::from_str(&lockfile_content).expect("Failed to parse rotriever.lock as TOML");
 
     let rotriever_index_path = dest_path.join("Packages/_Index");
@@ -69,88 +105,57 @@ fn get_packages_to_keep(package_names: &Vec<String>, dest_path: &Path) -> Vec<Pa
 
     // The goal is to know which folders to keep and which ones to prune
 
-    // TODO: Bundle up this loop into a new function that returns a list of paths to keep
-    for package in lockfile.package {
-        if package_names.contains(&package.name) {
-            let package_dependencies = package.dependencies.clone().unwrap_or(vec![]);
+    // TODO: Don't add duplicates
 
-            let root_dependency_path =
-                get_package_path_from_index(&package.name, &package.version, &rotriever_index_path);
+    fn process(
+        package: &RotrieverLockfilePackage,
+        rotriever_lockfile: &RotrieverLockfile,
+        rotriever_index_path: &Path,
+        packages_to_keep: &mut Vec<PathBuf>,
+    ) {
+        let package_dependencies = package.dependencies.clone().unwrap_or(vec![]);
 
-            if root_dependency_path.is_some() {
-                info!(
-                    "found source for {} at {}",
-                    package.name,
-                    root_dependency_path.unwrap().display()
-                );
+        if let Some(root_dependency_path) =
+            get_package_path_from_index(&package.name, &package.version, &rotriever_index_path)
+        {
+            if packages_to_keep.contains(&root_dependency_path) {
+                info!("already processed {}, skipping", package.name);
+                return;
             }
 
-            for dependency in package_dependencies {
-                let parts = dependency.split(" ").collect::<Vec<&str>>();
-                let package_name = parts[1];
-                let package_version = parts[2];
+            info!(
+                "found source for {} at {}",
+                package.name,
+                root_dependency_path.display()
+            );
+            packages_to_keep.push(root_dependency_path);
+        }
 
-                info!(
-                    "processing dependency: {} {}",
-                    package_name, package_version
-                );
-
-                let dependency_path = get_package_path_from_index(
-                    &package_name,
-                    &package_version,
+        for dependency in package_dependencies {
+            if let Some(dependency_package) =
+                get_package_from_dependency_string(dependency, &rotriever_lockfile)
+            {
+                process(
+                    &dependency_package,
+                    &rotriever_lockfile,
                     &rotriever_index_path,
+                    packages_to_keep,
                 );
-
-                // info!(
-                //     "dependency path for {}: {:?}",
-                //     package_name, dependency_path
-                // );
             }
         }
     }
 
-    // fn process_dependency(
-    //     package_name: &str,
-    //     packages_path: &Path,
-    //     packages_to_keep: &mut Vec<String>,
-    // ) {
-    //     info!("keeping dependency: {}", package_name);
-
-    //     // TODO: Handle if there are multiple versions of a package. i.e. if we
-    //     // want to include Foundation as a dependency, we need to make sure we
-    //     // use the right one. Maybe the most up-to-date?
-
-    //     let dependency_path = packages_path.join(INDEX_PATH).join(package_name);
-
-    //     let lockfile_path = dependency_path.join(LOCKFILE_NAME);
-    //     let lockfile_content = fs::read_to_string(lockfile_path).expect("Failed to read lockfile");
-
-    //     let lockfile: RotrieverLockfile =
-    //         toml::from_str(&lockfile_content).expect("Failed to parse TOML");
-
-    //     // TODO: Traverse over the dependencies to keep, use their lockfiles
-    //     // to determine which _other_ dependencies to keep, and then remove
-    //     // everything in the index and root of RobloxPackages that isn't in
-    //     // the keep list.
-
-    //     if let Some(deps) = lockfile.dependencies {
-    //         for sub_dependency in &deps {
-    //             let sub_dependency_parts: Vec<&str> = sub_dependency.split(" ").collect();
-    //             let sub_package_name = sub_dependency_parts[1];
-
-    //             info!("keeping dependency: {}", sub_package_name);
-
-    //             packages_to_keep.push(sub_package_name.to_string());
-
-    //             process_dependency(sub_package_name, packages_path, packages_to_keep);
-
-    //             // TODO: Go up into the index and process the sub-dependency
-
-    //             // TODO: Traverse over the dependencies of these
-    //             // dependencies and so on until we have the full picture
-    //         }
-    //     }
-    // }
+    for package_name in package_names {
+        if let Some(package) = get_package(package_name, None, &rotriever_lockfile) {
+            info!("processing top-level package: {}", package.name);
+            process(
+                &package,
+                &rotriever_lockfile,
+                &rotriever_index_path,
+                &mut packages_to_keep,
+            );
+        }
+    }
 
     packages_to_keep
 }
@@ -159,8 +164,77 @@ pub fn prune_unused_dependencies(package_names: &Vec<String>, dest_path: &Path) 
     info!("root packages to keep: {:?}", package_names);
     let packages_to_keep = get_packages_to_keep(package_names, dest_path);
 
-    // TODO: Loop over both `Packages` and `Packages/_Index` and remove all
-    // folders/files whose names don't match
+    debug!("packages to keep: {:?}", packages_to_keep);
 
-    info!("dependencies to keep: {:?}", packages_to_keep);
+    let packages_path = dest_path.join("Packages");
+    let package_index_path = packages_path.join("_Index");
+
+    let packages_paths = fs::read_dir(&packages_path)
+        .expect(format!("Failed to read {}", packages_path.display()).as_str());
+
+    for entry in packages_paths {
+        let entry = entry.expect(
+            format!(
+                "Failed to read directory entry in {}",
+                packages_path.display()
+            )
+            .as_str(),
+        );
+
+        let mut should_remove = true;
+
+        if entry.path() == package_index_path {
+            continue;
+        }
+
+        for package_name_to_keep in package_names {
+            if entry.file_name().to_string_lossy() == format!("{}.lua", package_name_to_keep) {
+                info!("keeping {}", entry.path().display());
+                should_remove = false;
+                continue;
+            }
+        }
+
+        if should_remove {
+            info!("removing unused package: {}", entry.path().display());
+            if entry.path().is_dir() {
+                fs::remove_dir_all(entry.path()).expect("Failed to remove directory");
+            } else {
+                fs::remove_file(entry.path()).expect("Failed to remove file");
+            }
+        }
+    }
+
+    // Prune anything not in packages_to_keep from Packages/_Index
+    let package_index_paths = fs::read_dir(&package_index_path)
+        .expect(format!("Failed to read {}", package_index_path.display()).as_str());
+
+    for entry in package_index_paths {
+        let entry = entry.expect(
+            format!(
+                "Failed to read directory entry in {}",
+                package_index_path.display()
+            )
+            .as_str(),
+        );
+
+        let mut should_remove = true;
+
+        for package_path_to_keep in &packages_to_keep {
+            if entry.path() == *package_path_to_keep {
+                info!("keeping {}", entry.path().display());
+                should_remove = false;
+                continue;
+            }
+        }
+
+        if should_remove {
+            info!("removing unused package index: {}", entry.path().display());
+            if entry.path().is_dir() {
+                fs::remove_dir_all(entry.path()).expect("Failed to remove directory");
+            } else {
+                fs::remove_file(entry.path()).expect("Failed to remove file");
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Problem

The RobloxPackages bundle size is 32 MB, with most of this space taken up by dependencies we're not even using. We need some way to prune those unused dependencies

# Solution

The CLI now takes a `--dependencies` flag which can be repeated for each dependency to keep.

As a full example, to install only Foundation and Signals, you would do:
```sh
roblox-packages install RobloxPackages -d Foundation -d Signals
```

As a quick comparison with `du` we can see that before we were clocking in at 32 MB, and now with dependency pruning we're down to just about half at 17 MB when including only Foundation and Signals.

Before:

```sh
➜  roblox-packages git:(prune-unused-dependencies) cargo run install RobloxPackages                                         
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/roblox-packages install RobloxPackages`
INFO: downloading packages for Roblox version 0.694.0.6940982
INFO: successfully installed packages from Roblox version 0.694.0.6940982 to /Users/dminnerly/git/roblox-packages/RobloxPackages
➜  roblox-packages git:(prune-unused-dependencies) du -h -d 1 RobloxPackages

 32M    RobloxPackages/Packages
 32M    RobloxPackages
```

After:

```sh
➜  roblox-packages git:(prune-unused-dependencies) cargo run install RobloxPackages -d Foundation -d Signals                
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/roblox-packages install RobloxPackages -d Foundation -d Signals`
...
➜  roblox-packages git:(prune-unused-dependencies) du -h -d 1 RobloxPackages                                 

 16M    RobloxPackages/Packages
 17M    RobloxPackages
```
