### PR TITLE
Listing historic versions broke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ defaults:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -69,7 +73,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install nextest
-        run: cargo binstall cargo-nextest
+        run: cargo binstall --locked cargo-nextest
 
       - name: Build
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "roblox-packages"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roblox-packages"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [lib]

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
-use crate::{install::install_roblox_packages, list::list_roblox_versions};
+use crate::{
+    install::install_roblox_packages,
+    list::{list_current_roblox_version, list_historic_roblox_versions},
+};
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
@@ -28,6 +31,9 @@ pub enum Command {
         #[arg(long, default_value_t = 20)]
         limit: usize,
     },
+
+    /// Prints the most recent Roblox version hash accepted by --version
+    CurrentVersion,
 }
 
 #[derive(Parser, Debug)]
@@ -39,7 +45,7 @@ pub struct CLI {
 }
 
 impl CLI {
-    pub async fn run(&self) -> Result<(), reqwest::Error> {
+    pub async fn run(&self) -> Result<()> {
         match &self.command {
             Command::Install {
                 dest,
@@ -48,7 +54,8 @@ impl CLI {
             } => {
                 install_roblox_packages(dest, version, dependencies).await?;
             }
-            Command::List { limit } => list_roblox_versions(limit).await?,
+            Command::List { limit } => list_historic_roblox_versions(limit).await?,
+            Command::CurrentVersion => list_current_roblox_version().await?,
         }
 
         Ok(())

--- a/src/install.rs
+++ b/src/install.rs
@@ -4,7 +4,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::roblox::{
-    fetch_roblox_deploy_history, fetch_roblox_packages, get_roblox_version_by_git_hash,
+    fetch_current_studio_version_id, fetch_roblox_deploy_history, fetch_roblox_packages,
+    get_roblox_version_by_git_hash,
 };
 
 use crate::rotriever::prune_unused_dependencies;
@@ -13,25 +14,30 @@ pub async fn install_roblox_packages(
     dest: &PathBuf,
     version: &Option<String>,
     dependencies: &Option<Vec<String>>,
-) -> Result<(), reqwest::Error> {
-    let version_history = fetch_roblox_deploy_history().await?;
-
-    let roblox_version = if let Some(version) = version {
+) -> Result<(), anyhow::Error> {
+    let hash = if let Some(version) = version {
         debug!("looking up Roblox version {}", version);
-        get_roblox_version_by_git_hash(version, &version_history).expect("Roblox version not found")
+
+        version.to_string()
     } else {
         debug!("no version specified, using most recent");
-        version_history
-            .last()
-            .expect("could not get a most recent version")
+
+        fetch_current_studio_version_id().await?
     };
 
-    info!(
-        "downloading packages for Roblox version {}",
-        roblox_version.git_hash
-    );
+    let version_id = if hash.contains('.') {
+        let version_history = fetch_roblox_deploy_history().await?;
+        let roblox_version = get_roblox_version_by_git_hash(&hash, &version_history)
+            .expect("Roblox version not found");
 
-    let mut archive = fetch_roblox_packages(&roblox_version).await?;
+        roblox_version.version_id.to_string()
+    } else {
+        hash.to_string()
+    };
+
+    info!("downloading packages for Roblox version {}", hash);
+
+    let mut archive = fetch_roblox_packages(&version_id).await?;
 
     let cwd = current_dir().unwrap();
     let dest_path = cwd.join(&dest);
@@ -66,7 +72,7 @@ pub async fn install_roblox_packages(
 
     info!(
         "successfully installed packages from Roblox version {} to {}",
-        roblox_version.git_hash,
+        hash,
         dest_path.display()
     );
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,11 +1,39 @@
-use crate::roblox::fetch_roblox_deploy_history;
+use anyhow::Result;
+use std::collections::HashSet;
 
-pub async fn list_roblox_versions(limit: &usize) -> Result<(), reqwest::Error> {
+use crate::roblox::{fetch_current_studio_version_id, fetch_roblox_deploy_history};
+
+pub async fn list_historic_roblox_versions(limit: &usize) -> Result<()> {
     let version_history = fetch_roblox_deploy_history().await?;
+    let mut seen_hashes = HashSet::new();
+    let mut deduped_versions = Vec::new();
 
-    for roblox_version in version_history.iter().rev().take(*limit).rev() {
-        println!("{} - {}", roblox_version.git_hash, roblox_version.timestamp)
+    for roblox_version in version_history.iter().rev() {
+        if !seen_hashes.insert(&roblox_version.git_hash) {
+            continue;
+        }
+
+        deduped_versions.push(roblox_version);
+
+        if deduped_versions.len() == *limit {
+            break;
+        }
     }
+
+    for roblox_version in deduped_versions.into_iter().rev() {
+        println!(
+            "{} ({}) - {}",
+            roblox_version.git_hash, roblox_version.version_id, roblox_version.timestamp
+        )
+    }
+
+    Ok(())
+}
+
+pub async fn list_current_roblox_version() -> Result<()> {
+    let version = fetch_current_studio_version_id().await?;
+
+    println!("{}", version);
 
     Ok(())
 }

--- a/src/roblox.rs
+++ b/src/roblox.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, anyhow};
 use log::debug;
 use regex::Regex;
 use std::io::Cursor;
@@ -24,9 +25,17 @@ pub async fn fetch_roblox_deploy_history() -> Result<Vec<RobloxVersion>, reqwest
         reqwest::StatusCode::OK => {
             let content = res.text().await?;
 
-            for (_, [_target, version_id, timestamp, git_hash]) in
+            for (_, [target, version_id, timestamp, git_hash]) in
                 re.captures_iter(&content).map(|c| c.extract())
             {
+                if target != "Studio64" {
+                    continue;
+                }
+
+                if version_id == "hidden" {
+                    continue;
+                }
+
                 history.push(RobloxVersion {
                     version_id: version_id.to_string(),
                     git_hash: git_hash.to_string(),
@@ -40,32 +49,49 @@ pub async fn fetch_roblox_deploy_history() -> Result<Vec<RobloxVersion>, reqwest
     Ok(history)
 }
 
+pub async fn fetch_current_studio_version_id() -> Result<String, anyhow::Error> {
+    let res = reqwest::get("https://setup.rbxcdn.com/versionQTStudio").await?;
+    let body = res.error_for_status()?.text().await?;
+    let trimmed = body.trim();
+
+    if let Some(version_id) = trimmed.strip_prefix("version-") {
+        Ok(version_id.to_string())
+    } else {
+        Err(anyhow!(
+            "unexpected response from versionQTStudio endpoint: {}",
+            trimmed
+        ))
+    }
+}
+
 pub async fn fetch_roblox_packages(
-    version: &RobloxVersion,
-) -> Result<ZipArchive<Cursor<Vec<u8>>>, reqwest::Error> {
-    debug!("downloading package archive for {}", version.version_id);
+    version_id: &str,
+) -> Result<ZipArchive<Cursor<Vec<u8>>>, anyhow::Error> {
+    debug!("downloading package archive for {}", version_id);
 
     let res = reqwest::get(format!(
         "https://setup.rbxcdn.com/version-{}-extracontent-luapackages.zip",
-        version.version_id
+        version_id
     ))
     .await?;
 
-    let body = res.bytes().await?;
+    let body = res.error_for_status()?.bytes().await?;
     let cursor = Cursor::new(body.to_vec());
-    let archive = ZipArchive::new(cursor).unwrap();
+    let archive =
+        ZipArchive::new(cursor).context("downloaded package archive is not a valid zip archive")?;
 
     Ok(archive)
 }
 
 pub fn get_roblox_version_by_git_hash<'a>(
     git_hash: &str,
-    version_history: &'a Vec<RobloxVersion>,
+    version_history: &'a [RobloxVersion],
 ) -> Option<&'a RobloxVersion> {
     for version in version_history.iter().rev() {
         if version.git_hash == git_hash {
             return Some(version);
         }
     }
-    return None;
+
+    None
 }


### PR DESCRIPTION
# Problem

All the recent Roblox version hashes from the `DeployHistory.txt` endpoint now show up as `version-hidden` which breaks our current version pinning.

# Solution

From this PR we now have:
1. **(BREAKING)** `roblox-packages install --version` now accepts a Roblox version hash instead of the dotted version. With this change you would pass: `--version d0e8cfcd943d4ae2`
2. `roblox-packages current-version` which will print out the current version hash (we now use the hash, not the 0.714 etc
3. `roblox-packages list` has been fixed to accommodate `version-hidden`

It doesn't look like there's another way to grab historic version hashes, though we can still grab the most recent. Version pinning should still work, it will just mean the upgrade strategy is to pull latest, pin it, and move forward from there

Resolves #8 
