### PR TITLE
Adopt Changewrite for releases and the shared AgentSkills library

### DIFF
--- a/.changes/README.md
+++ b/.changes/README.md
@@ -1,0 +1,30 @@
+# Change entries
+
+This folder holds the unreleased changes for the next release. Each file describes one change: how big a version bump it warrants and what to say about it in the changelog. At release time [Changewrite](https://github.com/flipbook-labs/changewrite) combines every entry here into `CHANGELOG.md`, bumps the version, and deletes the entries it consumed.
+
+## Adding an entry
+
+Create a markdown file in this folder. The filename is up to you — it only exists to make entries easy to browse — so name it after the change, e.g. `fix-release-permissions.md`:
+
+```markdown
+---
+bump: minor
+category: Features
+---
+
+Add support for Foo values so Bar can be Bazzed.
+```
+
+- **`bump`** (required) — how much to move the version: `major`, `minor`, or `patch`.
+- **`category`** (optional) — the heading this entry appears under in the changelog, e.g. `Features`, `Fixes`, `Dependencies`. Defaults to `Changes`.
+- **Body** — everything below the frontmatter is the changelog text. Aim for one or two sentences; it can span multiple paragraphs if a change needs it.
+
+## How the version is chosen
+
+The next version is the largest bump across all pending entries: a single `major` entry makes the release a major, otherwise a single `minor` makes it a minor, otherwise it's a `patch`. You don't pick the version yourself — you just say how big each change is.
+
+## Notes
+
+- `README.md` (this file) is ignored, so it's safe to keep here.
+- Entries are deleted once they're released; they live in this folder only while unreleased.
+- The folder location is configurable via `unreleased_changes` in `changewrite.toml` (it defaults to `./.changes/`).

--- a/.changes/adopt-changewrite-release-flow.md
+++ b/.changes/adopt-changewrite-release-flow.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Internal
+---
+
+Adopt the [Changewrite](https://github.com/flipbook-labs/changewrite) release flow. Releases are now driven by a publish PR that bumps the version across `Cargo.toml`, `Cargo.lock`, and `loom.config.luau` and assembles `CHANGELOG.md` from `.changes/` entries; merging it tags the release, drafts it, attaches the platform binaries, and publishes.

--- a/.changes/agent-skills-dev-dependency.md
+++ b/.changes/agent-skills-dev-dependency.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Dependencies
+---
+
+Add AgentSkills `v0.4.0` as a Loom dev dependency so agents can bootstrap the shared skills library.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,32 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'pull_request'
+    permissions:
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `require-entry` diffs against the PR base branch, so a merge-base must
+          # exist. Full history guarantees it (the default depth-1 checkout does not).
+          fetch-depth: 0
+
+      - uses: flipbook-labs/changewrite@v0.7.0
+        with:
+          require-entry: 'true'
+
+      # Clear the publish-lock status on this PR's head so a required check can pass.
+      # The publish PR gets its lock managed by the release workflow instead.
+      - uses: flipbook-labs/changewrite/publish-lock@v0.7.0
+        if: github.head_ref != 'publish-next-version'
+        with:
+          locked: false
+          sha: ${{ github.event.pull_request.head.sha }}
+          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,46 @@
 name: Release
 
 on:
-  pull_request:
-  release:
-    types: [published]
   push:
-    branches:
-      - main
+    branches: [main]
+  pull_request:
+    types: [
+        opened,
+        synchronize,
+        reopened,
+        # We include `labeled` so that tagging the PR with `debug:release-pr`
+        # will trigger a debug version of the release workflow.
+        labeled,
+      ]
+  workflow_dispatch:
+    inputs:
+      force-version:
+        description: "Open a publish PR that sets this exact version (e.g. 1.2.3)"
+        default: ""
+        required: false
 
 defaults:
   run:
     shell: bash
 
+env:
+  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
 jobs:
+  lock:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      statuses: write
+    steps:
+      - uses: flipbook-labs/changewrite/publish-lock@v0.7.0
+        with:
+          locked: true
+          url: ${{ env.RUN_URL }}
+
   init:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'debug:release-pr')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.value }}
@@ -28,6 +55,7 @@ jobs:
 
   build:
     needs: ["init"]
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'debug:release-pr')
     strategy:
       fail-fast: false
       matrix:
@@ -85,25 +113,93 @@ jobs:
           name: ${{ matrix.artifact-name }}
           path: release.zip
 
-  release-github:
-    name: Release (GitHub)
-    runs-on: ubuntu-latest
+  release:
+    name: Release
     needs: ["init", "build"]
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'debug:release-pr')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
+      pull-requests: write
+      statuses: write
+    outputs:
+      has_changes: ${{ steps.changewrite.outputs.has_changes }}
+      should_publish: ${{ steps.changewrite.outputs.should_publish }}
+      version: ${{ steps.changewrite.outputs.version }}
+      tag: ${{ steps.changewrite.outputs.tag }}
+    concurrency:
+      group: release-pr-${{ github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.FLIPBOOK_BACKEND_APP_ID }}
+          private-key: ${{ secrets.FLIPBOOK_BACKEND_APP_PRIVATE_KEY }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Use the App token so the version-bump PR triggers CI when pushed.
+          token: ${{ steps.app-token.outputs.token }}
+          # Build the changelog off `main` even on PR-triggered debug runs.
+          ref: main
+
+      - name: Download release assets
+        if: github.event_name != 'pull_request'
+        uses: actions/download-artifact@v4
         with:
           path: ./releases
 
       - name: Unpack releases
+        if: github.event_name != 'pull_request'
         run: ./scripts/unpack-releases.sh "./releases"
 
-      - uses: softprops/action-gh-release@v2
-        if: github.event.release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: flipbook-labs/changewrite@v0.7.0
+        id: changewrite
         with:
-          files: ./releases/*.zip
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-token: ${{ steps.app-token.outputs.token }}
+          force-version: ${{ inputs.force-version || '' }}
+          base: main
+          branch: ${{ github.event_name == 'pull_request' && 'debug-publish-next-version' || 'publish-next-version' }}
+          prepare-only: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'debug:release-pr') }}
+          # Attach the built platform binaries to the draft release before it's
+          # published so they ship with the release without a separate job.
+          post-draft-hook: |
+            "$CHANGEWRITE_BIN" attach --tag "$CHANGEWRITE_TAG" --files releases/*.zip
+          pr-title: ${{ github.event_name == 'pull_request' && '[DEBUG] Publish v{{version}}' || 'Publish v{{version}}' }}
+          pr-body: |
+            >[!IMPORTANT]
+            > This PR prepares the next release by bumping the version and updating the changelog.
+            >
+            > **Merging this PR will:**
+            >
+            > 1. Create and push tag `{{tag}}`
+            > 2. Create a draft GitHub release for that tag
+            > 3. Build binaries for macOS, Linux, and Windows and attach them
+            > 4. Publish the release
+
+            <details>
+            <summary><b>GitHub Release preview</b></summary>
+
+            # {{tag}}
+
+            **github-actions** released this 0 seconds ago 🔒 Immutable 🏷️ {{tag}} 🔗 SHA
+
+            {{notes}}
+            </details>
+
+            Next release will be available here:
+            {{repo_url}}/releases/tag/{{tag}}
+
+            🤖 This PR was generated by [this run]({{run_url}}).
+
+      - name: Unlock the publish PR
+        if: github.event_name == 'push'
+        uses: flipbook-labs/changewrite/publish-lock@v0.7.0
+        with:
+          locked: false
+          url: ${{ env.RUN_URL }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# roblox-packages agent guide
+
+roblox-packages is a Rust CLI that installs Roblox Luau packages (Foundation, Promise, Dash, and friends) into a project. It is a Cargo crate that ships as prebuilt binaries for macOS, Linux, and Windows. This file is the entry point for any agent working in the repo. It routes you to the shared skills library and the repo's own setup.
+
+## Mandatory first steps
+
+Complete every step below before you write any code, tests, changelog entries, or PR prose. This is a gate, and it does not depend on how you classify your task.
+
+1. Install the skills toolchain and dependencies:
+
+   ```sh
+   rokit install && lute pkg install
+   ```
+
+   `rokit install` puts `lute` on PATH, and `lute pkg install` fetches the Loom dependencies into `~/.loom/store`. The shared skills library is a dev dependency, so it lands in `~/.loom/store` for you to read; it is not part of the Rust build. Without this step the skills are not on disk. (The crate itself builds with Cargo — see "Repo specifics" — and does not need Loom.)
+
+2. Resolve the concrete skills path from the pinned version (do not guess it):
+
+   ```sh
+   ls -d ~/.loom/store/AgentSkills@*
+   ```
+
+   The store can hold more than one version, so match the `rev` pinned for `AgentSkills` in [`loom.config.luau`](loom.config.luau): the path is `~/.loom/store/AgentSkills@<rev>`. Use it wherever `<skills>` appears below, and ignore any other versions the listing prints.
+
+3. Read the routing index at `<skills>/AGENTS.md` in full. Its **Project Skills** section lists every skill with a trigger-rich one-liner, so you know what exists before you start. This read is unconditional.
+
+Deep reads of individual `<skills>/src/<scope>/<name>/SKILL.md` files stay on demand: when a task matches a trigger from the index, read that skill before doing the work it covers. Reading the index up front is what lets those triggers fire. Note that the shared library is Luau-oriented, so some skills will not apply to this Rust crate; use judgment.
+
+Reading a skill once does not mean you applied it when you wrote the code hours later. When you take a pass over a change and before you call a task done, follow the `org/review-pass` skill: it maps the diff to the skills that govern each file, has you re-open them at that point, runs the writing-style and code-comments critic passes over what you generated, and catches skill drift to feed back (see below).
+
+## Forward this file to subagents
+
+The Task tool spawns subagents in a fresh context that does not include this guide, so they never see the gate unless you hand it to them. Whenever you delegate to a subagent, you MUST include in its prompt:
+
+1. The mandatory first steps above (the bootstrap command and the index read).
+2. The concrete resolved path(s) to the specific `SKILL.md` files relevant to its task.
+
+Never assume a subagent will discover the skills on its own.
+
+## Keeping skills current
+
+Skills are living documents. When your work here contradicts a skill (a renamed symbol, a changed value, a fixed bug it still calls known), fix it in the agent-skills repo with a `.changes/` entry in the same effort. The fix reaches this repo on its next `rev` bump. The `org/review-pass` skill folds this check into closing out a task, so it fires without you having to remember it.
+
+## Repo specifics
+
+- This is a Rust crate. The toolchain is stable Rust via `rustup`; build with `cargo build`, lint with `cargo clippy --all-features` and `cargo fmt --check`, and run tests with `cargo nextest run` (or `cargo test`).
+- The library lives in [`src/`](src) and the CLI entry point is wired through `Cargo.toml`'s `[lib]`. `cargo run -- install <index>` is the primary smoke test.
+- Releases are handled by the [Changewrite](https://github.com/flipbook-labs/changewrite) action. The version of record is `current` in [`changewrite.toml`](changewrite.toml), mirrored into `Cargo.toml`, `Cargo.lock`, and `loom.config.luau`. Unreleased entries live as partials in [`.changes/`](.changes) and are assembled into [`CHANGELOG.md`](CHANGELOG.md) at release time. Add a `.changes/` entry for any user-facing change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+@AGENTS.md
+
+# Claude-specific routing
+
+Follow [`AGENTS.md`](AGENTS.md) first. Its "Mandatory first steps" gate (bootstrap, resolve the skills path, read the routing index in full) applies to you before any code, tests, changelog entries, or PR prose, and its subagent rule applies every time you use the Task tool.
+
+The one Claude-specific note: the shared skills live under `<skills>/src/<scope>/<name>/SKILL.md` (the `<skills>` path you resolve in step 2 of the gate), not in `.claude/skills/`, so the Skill tool does not surface them. You route to them yourself by following the gate above.

--- a/changewrite.toml
+++ b/changewrite.toml
@@ -1,0 +1,10 @@
+[version]
+current = "0.5.0"
+mirror = [
+  { file = "Cargo.toml" },
+  # Keep the crate's own entry in the lockfile in step so `cargo build --locked`
+  # still succeeds on the publish PR. The pattern targets the roblox-packages
+  # package block specifically so it never touches a dependency's version.
+  { file = "Cargo.lock", pattern = 'name = "roblox%-packages"%s+version = "([^"]+)"' },
+  { file = "loom.config.luau" },
+]

--- a/loom.config.luau
+++ b/loom.config.luau
@@ -1,0 +1,17 @@
+-- roblox-packages is a Rust crate, not a Loom package. This config exists only
+-- to declare the dev dependencies agents read locally (the shared skills
+-- library) and to carry a mirror of the release version. `version` is kept in
+-- sync with Cargo.toml by Changewrite; see changewrite.toml.
+return {
+	package = {
+		name = "roblox-packages",
+		version = "0.5.0",
+		dev_dependencies = {
+			AgentSkills = {
+				rev = "v0.4.0",
+				sourceKind = "github",
+				source = "https://github.com/flipbook-labs/agent-skills",
+			},
+		},
+	},
+}

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,0 +1,7 @@
+# This file lists tools managed by Rokit, a toolchain manager for Roblox projects.
+# For more information, see https://github.com/rojo-rbx/rokit
+
+# New tools can be added by running `rokit add <tool>` in a terminal.
+
+[tools]
+lute = "luau-lang/lute@1.0.1-nightly.20260701"


### PR DESCRIPTION
Brings roblox-packages in line with the rest of the org: releases are now driven by [Changewrite](https://github.com/flipbook-labs/changewrite), and the shared AgentSkills library is available to agents via Loom. This is the Rust adaptation of the org-wide Changewrite + AgentSkills pass.

## What changed

### Changewrite release flow

- **`changewrite.toml`** sets the version of record (`0.5.0`) and mirrors it into `Cargo.toml`, `Cargo.lock`, and `loom.config.luau`. The `Cargo.lock` mirror uses a pattern scoped to the crate's own `[[package]]` entry, so it never touches a dependency's version and `cargo build --locked` keeps passing on the publish PR. (Verified locally: `changewrite bump 0.6.0` changes exactly the one lockfile line.)
- **`release.yml` rewritten** around the publish-PR flow, mirroring `flipbook-cli`:
  - a `lock` job fails the `publish-lock` status on push so the open publish PR can't merge mid-regeneration;
  - the existing platform matrix builds the binaries;
  - the `release` job opens/updates the `publish-next-version` PR and, when that PR merges, tags the release, drafts it, attaches the per-platform zips via the existing `scripts/unpack-releases.sh` + `changewrite attach`, and publishes;
  - a final step unlocks the publish PR.
  - This **replaces the manual `release: published` trigger and the `release-github` job.**
- **`ci.yml`** gains a `changelog` job (`require-entry`) with a full-history checkout, and clears the `publish-lock` status on non-publish PR heads. **Contributors now need a `.changes/` entry per user-facing change.**
- Seeded `CHANGELOG.md` and `.changes/` (with a README) for the flow.

### Shared AgentSkills via Loom

- **`loom.config.luau`** (new) declares `AgentSkills v0.4.0` as a Loom dev dependency; **`rokit.toml`** (new) pins `lute` so `lute pkg install` can fetch it into `~/.loom/store`.
- **`AGENTS.md` / `CLAUDE.md`** add the bootstrap gate that routes agents to the shared skills index, noting the library is Luau-oriented so some skills won't apply to this Rust crate.

## Follow-ups

- For the lock to actually block merges, add `publish-lock` as a required status check on `main`'s branch protection rule. Without that it posts an informational status only.
- The release job uses the `FLIPBOOK_BACKEND_APP_*` org secrets (same as the other repos) so the publish PR triggers CI.
- The build matrix runs on every push to `main` (as in `flipbook-cli`) so binaries are ready to attach at publish time; can be optimized later if the cost matters.

## Test plan

- [ ] Merge, then confirm the first push to `main` opens a `publish-next-version` PR that bumps `Cargo.toml`/`Cargo.lock`/`loom.config.luau` together and assembles `CHANGELOG.md`.
- [ ] Confirm that publish PR's CI (`cargo build --locked`) passes.
- [ ] Merge the publish PR and confirm the tag, draft release, attached platform binaries, and publish all happen.

Made with [Cursor](https://cursor.com)